### PR TITLE
Error handling fixed & redirection link replaced

### DIFF
--- a/src/app/(pages)/favorites-page/page.tsx
+++ b/src/app/(pages)/favorites-page/page.tsx
@@ -37,7 +37,7 @@ const FavoritesPage = () => {
     } catch (error: any) {
       console.log("error: ", error);
       toast({
-        title: error.response.data.error.message || "something went wrong",
+        title: error.response.data?.error?.message || "Something went wrong!",
         status: "error",
         duration: 3000,
         isClosable: true,

--- a/src/app/(pages)/login/page.tsx
+++ b/src/app/(pages)/login/page.tsx
@@ -38,7 +38,7 @@ const LoginPage = () => {
     } catch (error: any) {
       console.log("error: ", error);
       toast({
-        title: error.response.data.error.message || "something went wrong",
+        title: error.response.data?.error?.message || "Something went wrong!",
         status: "error",
         duration: 3000,
         isClosable: true,

--- a/src/app/(pages)/sign-up/page.tsx
+++ b/src/app/(pages)/sign-up/page.tsx
@@ -38,7 +38,7 @@ const SignUpPage = () => {
     } catch (error: any) {
       console.log("error: ", error);
       toast({
-        title: error.response.data.error.message || "something went wrong",
+        title: error.response.data?.error?.message || "Something went wrong!",
         status: "error",
         duration: 3000,
         isClosable: true,
@@ -107,7 +107,7 @@ const SignUpPage = () => {
             Submit
           </Text>
         </Button>
-        <Link href="/sign-up" _hover={{}}>
+        <Link href="/login" _hover={{}}>
           <Text> Already a User? Log in</Text>
         </Link>
       </Flex>

--- a/src/app/(pages)/snippets-page/page.tsx
+++ b/src/app/(pages)/snippets-page/page.tsx
@@ -38,7 +38,7 @@ const SnippetsPage = () => {
     } catch (error: any) {
       console.log("error: ", error);
       toast({
-        title: error.response.data.error.message || "something went wrong",
+        title: error.response.data?.error?.message || "Something went wrong!",
         status: "error",
         duration: 3000,
         isClosable: true,

--- a/src/app/(pages)/snippets-page/page.tsx
+++ b/src/app/(pages)/snippets-page/page.tsx
@@ -30,10 +30,8 @@ const SnippetsPage = () => {
       const resData: RequestSnippetType = await getData(query);
       if (!resData.status) {
         setError(true);
-        setLoading(false);
       } else {
         setData(resData.snippets);
-        setLoading(false);
       }
     } catch (error: any) {
       console.log("error: ", error);
@@ -43,6 +41,8 @@ const SnippetsPage = () => {
         duration: 3000,
         isClosable: true,
       });
+    } finally {
+      setLoading(false);
     }
   };
   useEffect(() => {

--- a/src/components/AuthComponents/LoginButton.tsx
+++ b/src/components/AuthComponents/LoginButton.tsx
@@ -32,7 +32,7 @@ const LoginButton = ({ type = "desk" }: { type?: string }) => {
     } catch (error: any) {
       console.log("error: ", error);
       toast({
-        title: error.response.data.error.message || "something went wrong",
+        title: error.response.data?.error?.message || "Something went wrong!",
         status: "error",
         duration: 3000,
         isClosable: true,


### PR DESCRIPTION
## Fixed few error handlings

1. Sometimes the error obj from the `axios` throws a string so for that I've updated the error handling by using "error.response.data?.error?.message || `Something went wrong !`"
2. Due to not having the `.env` file the snippets page's loading was not ending on the error stage. Just updated that part
3. You forget to place the URL for login page in the sign-up page so I just faced this issue in your production application and think to fix this.


Hoping you'll check this details on my contribution.

###  I found few more bugs on your production application

Looking forward to contribute more 🙂